### PR TITLE
More CMake fixes in install space

### DIFF
--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -13,18 +13,40 @@ find_path(DARKNET_PATH
 message(STATUS "Darknet path dir = ${DARKNET_PATH}")
 add_definitions(-DDARKNET_FILE_PATH="${DARKNET_PATH}")
 
+EXECUTE_PROCESS( COMMAND uname -m COMMAND tr -d '\n' OUTPUT_VARIABLE ARCHITECTURE )
+message( STATUS "System architecture: ${ARCHITECTURE}" )
+
 # Find CUDA
 find_package(CUDA QUIET)
 if (CUDA_FOUND)
   find_package(CUDA REQUIRED)
   message(STATUS "CUDA Version: ${CUDA_VERSION_STRINGS}")
   message(STATUS "CUDA Libararies: ${CUDA_LIBRARIES}")
-  set(
-    CUDA_NVCC_FLAGS
-    ${CUDA_NVCC_FLAGS};
-    -O3
-    -gencode arch=compute_50,code=[sm_50,compute_50]
-  )
+  if (${ARCHITECTURE} STREQUAL "aarch64")
+    set(
+      CUDA_NVCC_FLAGS
+      ${CUDA_NVCC_FLAGS};
+      -O3
+      -gencode arch=compute_72,code=[sm_72,compute_72]
+    )
+    message(STATUS "Using CUDA computability: 7.2")
+  elseif(${ARCHITECTURE} STREQUAL "x86_64")
+    set(
+      CUDA_NVCC_FLAGS
+      ${CUDA_NVCC_FLAGS};
+      -O3
+      -gencode arch=compute_75,code=[sm_75,compute_75]
+    )
+    message(STATUS "Using CUDA computability: 7.5")
+  else()
+    set(
+      CUDA_NVCC_FLAGS
+      ${CUDA_NVCC_FLAGS};
+      -O3
+      -gencode arch=compute_50,code=[sm_50,compute_50]
+    )
+    message(STATUS "Using CUDA computability: 5.0")
+  endif()
   add_definitions(-DGPU)
 else()
   list(APPEND LIBRARIES "m")

--- a/darknet_ros/CMakeLists.txt
+++ b/darknet_ros/CMakeLists.txt
@@ -250,6 +250,11 @@ install(DIRECTORY config launch yolo_network_config
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )
 
+install(FILES
+  nodelet_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 # Download yolov2-tiny.weights
 set(PATH "${CMAKE_CURRENT_SOURCE_DIR}/yolo_network_config/weights")
 set(FILE "${PATH}/yolov2-tiny.weights")


### PR DESCRIPTION
1. Fully copy over necessary files from build space to install space
2. Add naive way of determining CUDA computability by system architecture -- x64 use 7.5 (for RTX 2060 Super), aarch64 use 7.2 (for Xavier NX Dev Board onboard GPU)

TODO:
- Figure out more sophisticated way to determine CUDA computability for compilation